### PR TITLE
Fix edit chat title

### DIFF
--- a/src/app/_components/ModelSelector.tsx
+++ b/src/app/_components/ModelSelector.tsx
@@ -34,8 +34,8 @@ const anthropicModels: AnthropicMessagesModelId[] = [
 ];
 
 const geminiMOdels: GoogleGenerativeAIModelId[] = [
-  "gemini-1.5-flash",
-  "gemini-1.5-pro",
+  // "gemini-1.5-flash",
+  // "gemini-1.5-pro",
   "gemini-2.0-flash",
   "gemini-2.0-flash-lite",
   "gemini-2.5-flash",

--- a/src/app/_components/sidebar/ChatItem.tsx
+++ b/src/app/_components/sidebar/ChatItem.tsx
@@ -27,6 +27,8 @@ import {
   type FC,
   type FormEventHandler,
   useOptimistic,
+  useRef,
+  useEffect,
   useState,
   useTransition,
 } from "react";
@@ -39,6 +41,8 @@ export const ChatItem: FC<{
   chatId?: string;
 }> = ({ chat, chatId }) => {
   const { replace } = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const onRemoveClick = async () => {
     await removeChatById(chat.id);
     revalidateChats();
@@ -59,6 +63,27 @@ export const ChatItem: FC<{
   );
 
   const [isUpdating, startTransition] = useTransition();
+
+  useEffect(() => {
+    const handleClickOutside = ({ target }: MouseEvent) => {
+      if (isEditMode && target !== inputRef.current) {
+        const isDropdownMenuItem =
+          target instanceof Element && target.closest('[role="menuitem"]');
+        if (!isDropdownMenuItem) {
+          setIsEditMode(false);
+        }
+      }
+    };
+
+    if (isEditMode) {
+      inputRef.current?.focus();
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isEditMode]);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (ev) => {
     ev.preventDefault();
@@ -119,9 +144,7 @@ export const ChatItem: FC<{
           <Input
             name="newName"
             defaultValue={chat.name ?? undefined}
-            ref={(input) => {
-              input?.focus();
-            }}
+            ref={inputRef}
           />
         </form>
       )}

--- a/src/app/api/aichat/getModel.ts
+++ b/src/app/api/aichat/getModel.ts
@@ -25,7 +25,7 @@ export function getModel({
         );
       case "gemini":
         return createGoogleGenerativeAI({ apiKey })(
-          modelId ?? "gemini-1.5-flash"
+          modelId ?? "gemini-2.0-flash"
         ) as unknown as LanguageModel;
       default:
         return openai("gpt-3.5-turbo");


### PR DESCRIPTION
#### created by OpenAI  
# Pull Request Description

## Summary
This pull request includes updates to the `ModelSelector`, `ChatItem`, and `getModel` components. Key changes involve model deprecation, enhancements to the chat item editing experience, and a default model ID update.

## Changes Made

### ModelSelector.tsx
- Commented out deprecated models:
  - `"gemini-1.5-flash"`
  - `"gemini-1.5-pro"`

### ChatItem.tsx
- Added `useRef` and `useEffect` hooks:
  - Introduced `inputRef` to manage focus on the input field.
  - Implemented a click outside handler to exit edit mode when clicking outside the input.
- Updated the input field reference to use `inputRef` for better focus management.

### getModel.ts
- Changed the default model ID for the "gemini" case:
  - Updated from `"gemini-1.5-flash"` to `"gemini-2.0-flash"`.

## Impact
These changes improve the user experience by ensuring deprecated models are not used and enhancing the chat item editing functionality. The default model ID update aligns with the latest model offerings.