### PR TITLE
fix: improve edit chat title outside click detection

### DIFF
--- a/src/app/_components/sidebar/ChatItem.tsx
+++ b/src/app/_components/sidebar/ChatItem.tsx
@@ -31,6 +31,7 @@ import {
   useEffect,
   useState,
   useTransition,
+  useId,
 } from "react";
 import { Spinner } from "../Spinner";
 import { useRouter } from "next/navigation";
@@ -64,11 +65,13 @@ export const ChatItem: FC<{
 
   const [isUpdating, startTransition] = useTransition();
 
+  const menuId = `menu_${useId()}`;
+
   useEffect(() => {
     const handleClickOutside = ({ target }: MouseEvent) => {
       if (isEditMode && target !== inputRef.current) {
         const isDropdownMenuItem =
-          target instanceof Element && target.closest('[role="menuitem"]');
+          target instanceof Element && target.closest(`#${menuId}`);
         if (!isDropdownMenuItem) {
           setIsEditMode(false);
         }
@@ -77,11 +80,11 @@ export const ChatItem: FC<{
 
     if (isEditMode) {
       inputRef.current?.focus();
-      document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener("click", handleClickOutside);
     }
 
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("click", handleClickOutside);
     };
   }, [isEditMode]);
 
@@ -122,7 +125,7 @@ export const ChatItem: FC<{
                   <EllipsisIcon className="hidden group-hover/menu-item:block" />
                 </SidebarMenuAction>
               </DropdownMenuTrigger>
-              <DropdownMenuContent>
+              <DropdownMenuContent id={menuId}>
                 <DropdownMenuItem onClick={onEditClick}>
                   <PencilIcon />
                   <span>Edit title</span>


### PR DESCRIPTION
- Use unique menu ID to better target dropdown menu clicks
- Change from mousedown to click event for more reliable detection
- Add useId hook for generating unique menu identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)