### PR TITLE
fix: Restore Date format of cached chats & Fixes #13

### DIFF
--- a/src/app/_components/sidebar/ChatHistory.tsx
+++ b/src/app/_components/sidebar/ChatHistory.tsx
@@ -9,9 +9,7 @@ export const ChatHistory: FC<{ userId?: string; chatId?: string }> = async ({
 }) => {
   let chats: (Chat & { messages: Message[] })[] = [];
   if (userId) {
-    const getUsersChats = await cachedUsersChats(userId);
-
-    chats = await getUsersChats(userId);
+    chats = await cachedUsersChats(userId);
   }
   return (
     <>

--- a/src/services/getUsersChats.ts
+++ b/src/services/getUsersChats.ts
@@ -3,8 +3,8 @@
 import { revalidateTag, unstable_cache } from "next/cache";
 import { db } from "../lib/prisma";
 
-export const getUsersChats = async (userId: string) =>
-  unstable_cache(
+export const getUsersChats = async (userId: string) => {
+  const cachedChats = unstable_cache(
     (userId: string) =>
       db.chat.findMany({
         include: { messages: true },
@@ -14,6 +14,18 @@ export const getUsersChats = async (userId: string) =>
     [userId],
     { tags: ["chats"] }
   );
+
+  const chats = await cachedChats(userId);
+  // Restoration Date format of cached chats
+  return chats.map((chat) => ({
+    ...chat,
+    created: new Date(chat.created),
+    messages: chat.messages.map((msg) => ({
+      ...msg,
+      ...(msg.createdAt && { createdAt: new Date(msg.createdAt) }),
+    })),
+  }));
+};
 
 export async function revalidateChats() {
   revalidateTag("chats");


### PR DESCRIPTION
#### created by OpenAI  
# Pull Request Description

## Summary
This pull request refactors the `ChatHistory` component and the `getUsersChats` service to improve code clarity and efficiency.

## Changes Made
- **ChatHistory Component**:
  - Removed unnecessary variable assignment for `getUsersChats`.
  - Directly assigned the result of `cachedUsersChats(userId)` to `chats`.

- **getUsersChats Service**:
  - Wrapped the `unstable_cache` call in a variable `cachedChats` for better readability.
  - Added a mapping function to format the restoration date of cached chats:
    - Converted `created` date to a `Date` object.
    - Converted `createdAt` of messages to a `Date` object if it exists.

## Benefits
- Simplifies the logic in `ChatHistory`.
- Enhances the readability and maintainability of the `getUsersChats` function.
- Ensures that date fields are consistently formatted as `Date` objects.